### PR TITLE
Set DOWNLOAD_ONLY option for dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,9 @@
+name: build
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  x86_64-linux-gnu-gcc:
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.4

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,5 +19,11 @@
       "isBackground": true,
       "command": "ninja -C build QtBreezeStyleSheets"
     },
+    {
+      "label": "Ninja QtBreezeImageViewer",
+      "type": "shell",
+      "isBackground": true,
+      "command": "ninja -C build QtBreezeImageViewer"
+    },
   ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,20 +4,36 @@ include(FetchContent)
 FetchContent_Declare(
   CMakeModules
   GIT_REPOSITORY https://github.com/ZIMO-Elektronik/CMakeModules
-  GIT_TAG v0.5.0)
+  GIT_TAG v0.7.0)
 FetchContent_MakeAvailable(CMakeModules)
 
 version_from_git()
 project(QtBreeze VERSION ${VERSION_FROM_GIT})
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 find_qt(REQUIRED COMPONENTS Core)
 
-cpmaddpackage("gh:KDE/breeze-icons@${PROJECT_VERSION}")
 cpmaddpackage(
-  "gh:Alexhuszagh/BreezeStyleSheets#69d2e7476428216e66143ff7b5c99553d7a2784f")
+  NAME
+  breeze-icons
+  GITHUB_REPOSITORY
+  KDE/breeze-icons
+  VERSION
+  ${PROJECT_VERSION}
+  DOWNLOAD_ONLY
+  TRUE)
+cpmaddpackage(
+  NAME
+  BreezeStyleSheets
+  GITHUB_REPOSITORY
+  Alexhuszagh/BreezeStyleSheets
+  GIT_TAG
+  69d2e7476428216e66143ff7b5c99553d7a2784f
+  DOWNLOAD_ONLY
+  TRUE)
 
 set(SRC ${breeze-icons_SOURCE_DIR}/qtbreeze_icons.qrc)
 add_library(QtBreezeIcons ${SRC})

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # QtBreeze
 
+[![build](https://github.com/ZIMO-Elektronik/QtBreeze/actions/workflows/build.yml/badge.svg)](https://github.com/ZIMO-Elektronik/QtBreeze/actions/workflows/build.yml)
+
 <img src="data/images/logo.png" width="15%" align="right"/>
 
 QtBreeze is a CMake wrapper for KDE's [breeze-icons](https://github.com/KDE/breeze-icons) and [BreezeStyleSheets](https://github.com/Alexhuszagh/BreezeStyleSheets). It combines both repositories into two seperate [Qt resource files](https://doc.qt.io/qt-5/resources.html#resource-collection-files-op-op-qrc), which can then be easily included in other Qt projects.


### PR DESCRIPTION
Since we don't really need the targets created by [breeze-icons](https://github.com/KDE/breeze-icons) [CMakeLists.txt](https://github.com/KDE/breeze-icons/blob/master/CMakeLists.txt) file we can safely set the DOWNLOAD_ONLY option. This has the benefit that certain dependencies of breeze-icons (e.g. [ECM](https://github.com/KDE/extra-cmake-modules)) are eliminated.